### PR TITLE
refactors 'can be marked as favourite' test

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/timelines/creation.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/timelines/creation.spec.ts
@@ -13,6 +13,7 @@ import {
   NOTES_TEXT,
   PIN_EVENT,
   SERVER_SIDE_EVENT_COUNT,
+  STAR_ICON,
   TIMELINE_FILTER,
   TIMELINE_FLYOUT_WRAPPER,
   TIMELINE_PANEL,
@@ -110,14 +111,12 @@ describe('Timelines', (): void => {
     });
 
     it('can be marked as favorite', () => {
-      cy.intercept('PATCH', '/api/timeline/_favorite').as('markAsFavourite');
       markAsFavorite();
-      cy.wait('@markAsFavourite', { timeout: 10000 }).its('response.statusCode').should('eq', 200);
 
+      cy.get(STAR_ICON).should('not.exist');
       cy.get(FAVORITE_TIMELINE).should('have.text', 'Remove from favorites');
       cy.visit(OVERVIEW_URL);
       cy.get(OVERVIEW_REVENT_TIMELINES).should('contain', timeline.title);
-      openTimelineUsingToggle();
     });
   });
 });


### PR DESCRIPTION
## Summary

Checking the flakiness builds I saw per the screenshot that looks like it is a problem with the API calls.

<img width="1276" alt="Screenshot 2021-06-14 at 15 56 29" src="https://user-images.githubusercontent.com/17427073/121904791-cbb63000-cd29-11eb-9030-92e326d75047.png">

This test has been refactored in order to don't use it.
